### PR TITLE
Draft: Authenticate requests with cookie

### DIFF
--- a/herbit.rb
+++ b/herbit.rb
@@ -1,4 +1,5 @@
 require 'faraday'
+require 'uri'
 require 'faraday/net_http'
 Faraday.default_adapter = :net_http
 
@@ -20,7 +21,16 @@ class Herbit
   private
 
   def run(cmd, sink)
-    connection.post do |req|
+    encoded_params = URI.encode_www_form({ password: "lidlut-tabwed-pillex-ridrup" })
+    response = connection.post(
+        "http://localhost:8080/~/login",
+        encoded_params
+      )
+    cookie = response.headers['set-cookie']
+    cookie = cookie.split(';')[0]
+
+    response = connection.post do |req|
+      req.headers['Cookie'] = cookie
       req.body = {
         source: { dojo: cmd },
         sink: sink

--- a/herbit.rb
+++ b/herbit.rb
@@ -23,7 +23,7 @@ class Herbit
   def run(cmd, sink)
     encoded_params = URI.encode_www_form({ password: "lidlut-tabwed-pillex-ridrup" })
     response = connection.post(
-        "http://localhost:#{@port}/~/login",
+        "http://localhost:8080/~/login",
         encoded_params
       )
     cookie = response.headers['set-cookie']

--- a/herbit.rb
+++ b/herbit.rb
@@ -23,7 +23,7 @@ class Herbit
   def run(cmd, sink)
     encoded_params = URI.encode_www_form({ password: "lidlut-tabwed-pillex-ridrup" })
     response = connection.post(
-        "http://localhost:8080/~/login",
+        "http://localhost:#{@port}/~/login",
         encoded_params
       )
     cookie = response.headers['set-cookie']


### PR DESCRIPTION
Hi Tom!  I'm currently building an [auto-glob pipeline](https://github.com/ajlamarc/urbit-cicd-testing/blob/main/bounce-config.yml) using bouncer, and on the `-garden!make-glob` step the request is denied because the request is unauthenticated.

This change retrieves a cookie first and provides it in the request, which solves the issue.  But, it currently assumes the ship is `zod` and port is `8080` (forgive my lack of Ruby experience).